### PR TITLE
Deprecate elk logstash cookbook

### DIFF
--- a/attributes/certs.rb
+++ b/attributes/certs.rb
@@ -1,2 +1,7 @@
 default['elk_forwarder']['cert_data_bag']      = 'certificates'
 default['elk_forwarder']['cert_data_bag_item'] = 'logstash'
+default['elk_forwarder']['ca_cert']['self_signed'] = {
+  'org' => 'Log Server Self Signed',
+  'org_unit' => '.',
+  'country' => 'US'
+}

--- a/recipes/certs.rb
+++ b/recipes/certs.rb
@@ -28,6 +28,7 @@ if node['elk_forwarder']['generate_cert']
       key_file node['elk_forwarder']['ca_cert']['self_signed']['signing_key']
     end
     notifies :restart, 'service[logstash-forwarder]'
+    not_if { ::File.exist? ca_cert } # Necessary because of a bug in openssl_x509
   end
 else
   file ca_cert do

--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -30,3 +30,5 @@ file "#{node['elk_forwarder']['config_dir']}/logstash-forwarder.conf" do
   )
   notifies :restart, "service[#{node['elk_forwarder']['service_name']}]"
 end
+
+include_recipe 'elk_forwarder::certs'


### PR DESCRIPTION
Mainly involves code to do our own certificate setup but breaks backwards compatibility because it no longer installs the Cert and Key (now handled by logserver).

Required by evertrue/et_logger-cookbook#1 and by the testing components in evertrue/logserver-cookbook#1